### PR TITLE
First steps for DynamoDB query generation

### DIFF
--- a/src/main/java/com/exasol/adapter/dynamodb/DynamodbAdapter.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/DynamodbAdapter.java
@@ -123,10 +123,11 @@ public class DynamodbAdapter implements VirtualSchemaAdapter {
 
     private String runQuery(final ExaMetadata exaMetadata, final PushDownRequest request,
             final QueryResultTableSchema queryResultTableSchema) throws ExaConnectionAccessException {
-        final QueryRunner queryRunner = new QueryRunner(getConnectionInformation(exaMetadata, request));
+        final DynamodbQueryRunner dynamodbQueryRunner = new DynamodbQueryRunner(
+                getConnectionInformation(exaMetadata, request));
         final RowMapper rowMapper = new RowMapper(queryResultTableSchema);
         final List<List<ValueExpression>> resultRows = new ArrayList<>();
-        queryRunner.runQuery(queryResultTableSchema)
+        dynamodbQueryRunner.runQuery(queryResultTableSchema)
                 .forEach(dynamodbRow -> resultRows.add(rowMapper.mapRow(dynamodbRow)));
         return new ValueExpressionsToSqlSelectFromValuesConverter().convert(queryResultTableSchema, resultRows);
     }

--- a/src/main/java/com/exasol/adapter/dynamodb/DynamodbQueryRunner.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/DynamodbQueryRunner.java
@@ -13,16 +13,15 @@ import com.exasol.dynamodb.DynamodbConnectionFactory;
 /**
  * This class runs a DynamoDB query to fetch the data requested in a {@link QueryResultTableSchema}.
  */
-public class QueryRunner {
+public class DynamodbQueryRunner {
     private final ExaConnectionInformation connectionSettings;
 
     /**
-     * Creates an instance of {@link QueryRunner}.
+     * Creates an instance of {@link DynamodbQueryRunner}.
      *
      * @param connectionSettings connection information for the connection to DynamoDB
      */
-    public QueryRunner(final ExaConnectionInformation connectionSettings) {
-
+    public DynamodbQueryRunner(final ExaConnectionInformation connectionSettings) {
         this.connectionSettings = connectionSettings;
     }
 
@@ -34,7 +33,9 @@ public class QueryRunner {
      */
     public Stream<Map<String, AttributeValue>> runQuery(final QueryResultTableSchema query) {
         final AmazonDynamoDB client = getConnection();
-        return client.scan(new ScanRequest(query.getFromTable().getRemoteName())).getItems().stream();
+        final String tableName = query.getFromTable().getRemoteName();
+        final ScanRequest scanRequest = new ScanRequest(tableName);
+        return client.scan(scanRequest).getItems().stream();
     }
 
     private AmazonDynamoDB getConnection() {

--- a/src/main/java/com/exasol/adapter/dynamodb/QueryRunner.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/QueryRunner.java
@@ -1,0 +1,13 @@
+package com.exasol.adapter.dynamodb;
+
+import com.exasol.adapter.dynamodb.queryresultschema.QueryResultTableSchema;
+
+public class QueryRunner {
+    public void runQuery(final QueryResultTableSchema query) {
+
+        // 1. select table
+        // 2. select method (selection)
+        // 3. add projection
+        // 3. run
+    }
+}

--- a/src/main/java/com/exasol/adapter/dynamodb/QueryRunner.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/QueryRunner.java
@@ -10,27 +10,35 @@ import com.exasol.ExaConnectionInformation;
 import com.exasol.adapter.dynamodb.queryresultschema.QueryResultTableSchema;
 import com.exasol.dynamodb.DynamodbConnectionFactory;
 
+/**
+ * This class runs a DynamoDB query to fetch the data requested in a {@link QueryResultTableSchema}.
+ */
 public class QueryRunner {
-
     private final ExaConnectionInformation connectionSettings;
 
+    /**
+     * Creates an instance of {@link QueryRunner}.
+     *
+     * @param connectionSettings connection information for the connection to DynamoDB
+     */
     public QueryRunner(final ExaConnectionInformation connectionSettings) {
 
         this.connectionSettings = connectionSettings;
     }
 
+    /**
+     * Executes a query on DynamoDB.
+     * 
+     * @param query requested information
+     * @return stream of results
+     */
+    public Stream<Map<String, AttributeValue>> runQuery(final QueryResultTableSchema query) {
+        final AmazonDynamoDB client = getConnection();
+        return client.scan(new ScanRequest(query.getFromTable().getRemoteName())).getItems().stream();
+    }
+
     private AmazonDynamoDB getConnection() {
         return new DynamodbConnectionFactory().getLowLevelConnection(this.connectionSettings.getAddress(),
                 this.connectionSettings.getUser(), this.connectionSettings.getPassword());
-    }
-
-    public Stream<Map<String, AttributeValue>> runQuery(final QueryResultTableSchema query) {
-
-        final AmazonDynamoDB client = getConnection();
-        return client.scan(new ScanRequest(query.getFromTable().getRemoteName())).getItems().stream();
-
-        // 2. select method (selection)
-        // 3. add projection
-        // 3. run
     }
 }

--- a/src/main/java/com/exasol/adapter/dynamodb/QueryRunner.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/QueryRunner.java
@@ -1,11 +1,34 @@
 package com.exasol.adapter.dynamodb;
 
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.exasol.ExaConnectionInformation;
 import com.exasol.adapter.dynamodb.queryresultschema.QueryResultTableSchema;
+import com.exasol.dynamodb.DynamodbConnectionFactory;
 
 public class QueryRunner {
-    public void runQuery(final QueryResultTableSchema query) {
 
-        // 1. select table
+    private final ExaConnectionInformation connectionSettings;
+
+    public QueryRunner(final ExaConnectionInformation connectionSettings) {
+
+        this.connectionSettings = connectionSettings;
+    }
+
+    private AmazonDynamoDB getConnection() {
+        return new DynamodbConnectionFactory().getLowLevelConnection(this.connectionSettings.getAddress(),
+                this.connectionSettings.getUser(), this.connectionSettings.getPassword());
+    }
+
+    public Stream<Map<String, AttributeValue>> runQuery(final QueryResultTableSchema query) {
+
+        final AmazonDynamoDB client = getConnection();
+        return client.scan(new ScanRequest(query.getFromTable().getRemoteName())).getItems().stream();
+
         // 2. select method (selection)
         // 3. add projection
         // 3. run

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/ArrayAllPathSegment.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/ArrayAllPathSegment.java
@@ -4,6 +4,8 @@ package com.exasol.adapter.dynamodb.documentpath;
  * This path segment describes that all children of an array are part of the path.
  */
 public class ArrayAllPathSegment implements PathSegment {
+    private static final long serialVersionUID = 1742087357300081487L;
+
     @Override
     public void accept(final PathSegmentVisitor visitor) {
         visitor.visit(this);

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/ArrayLookupPathSegment.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/ArrayLookupPathSegment.java
@@ -4,6 +4,7 @@ package com.exasol.adapter.dynamodb.documentpath;
  * This path segment defines an array lookup in an path expression.
  */
 public class ArrayLookupPathSegment implements PathSegment {
+    private static final long serialVersionUID = 2894278065231221419L;
     private final int lookupIndex;
 
     /**

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathExpression.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathExpression.java
@@ -1,5 +1,6 @@
 package com.exasol.adapter.dynamodb.documentpath;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -7,11 +8,13 @@ import java.util.List;
 /**
  * This class allows to express path through a document.
  */
-public class DocumentPathExpression {
-    private final List<PathSegment> path;
+public class DocumentPathExpression implements Serializable {
+    private static final long serialVersionUID = -5010657725802907603L;
+    private final ArrayList<PathSegment> path;
 
     private DocumentPathExpression(final List<PathSegment> path) {
-        this.path = path;
+        this.path = new ArrayList<>(path.size());
+        this.path.addAll(path);
     }
 
     List<PathSegment> getPath() {

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathExpression.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathExpression.java
@@ -19,7 +19,7 @@ public class DocumentPathExpression {
     }
 
     /**
-     * Creates a sub path from startIndex (inclusive) til endIndex (exclusive).
+     * Creates a subpath from startIndex (inclusive) til endIndex (exclusive).
      * 
      * @param startIndex index in path for new path to start
      * @param endIndex   index in path for new path to end

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathExpression.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathExpression.java
@@ -19,7 +19,7 @@ public class DocumentPathExpression {
     }
 
     /**
-     * Creates a subpath from startIndex (inclusive) til endIndex (exclusive).
+     * Creates a sub path from startIndex (inclusive) til endIndex (exclusive).
      * 
      * @param startIndex index in path for new path to start
      * @param endIndex   index in path for new path to end

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/ObjectLookupPathSegment.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/ObjectLookupPathSegment.java
@@ -4,6 +4,7 @@ package com.exasol.adapter.dynamodb.documentpath;
  * Path segment defining a key lookup of an object.
  */
 public class ObjectLookupPathSegment implements PathSegment {
+    private static final long serialVersionUID = -753364340469270540L;
     private final String lookupKey;
 
     /**

--- a/src/main/java/com/exasol/adapter/dynamodb/documentpath/PathSegment.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/documentpath/PathSegment.java
@@ -1,9 +1,11 @@
 package com.exasol.adapter.dynamodb.documentpath;
 
+import java.io.Serializable;
+
 /**
  * Interface for path segments used in a {@link DocumentPathExpression}.
  */
-public interface PathSegment {
+public interface PathSegment extends Serializable {
     /**
      * Accepts a {@link PathSegmentVisitor}
      * 

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/AbstractValueMapper.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/AbstractValueMapper.java
@@ -26,10 +26,13 @@ public abstract class AbstractValueMapper {
      * Extracts {@link #column}s value from DynamoDB's result row.
      *
      * @param dynamodbRow to extract the value from
-     * @return {@link ValueExpression} @ if specified property can't be extracted and
-     * {@link AbstractColumnMappingDefinition.LookupFailBehaviour} exception
-     * @throws ValueMapperException if specified property can't be mapped and
-     *                              {@link AbstractColumnMappingDefinition.LookupFailBehaviour} exception
+     * @return {@link ValueExpression}
+     * @throws DynamodbResultWalkerException if specified property was not found and
+     *                                       {@link AbstractColumnMappingDefinition.LookupFailBehaviour} is set to
+     *                                       {@code EXCEPTION }
+     * @throws ValueMapperException          if specified property can't be mapped and
+     *                                       {@link AbstractColumnMappingDefinition.LookupFailBehaviour} is set to
+     *                                       {@code EXCEPTION }
      */
     public ValueExpression mapRow(final Map<String, AttributeValue> dynamodbRow) {
         try {

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/AbstractValueMapper.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/AbstractValueMapper.java
@@ -26,14 +26,12 @@ public abstract class AbstractValueMapper {
      * Extracts {@link #column}s value from DynamoDB's result row.
      *
      * @param dynamodbRow to extract the value from
-     * @return {@link ValueExpression}
-     * @throws DynamodbResultWalkerException if specified property can't be extracted and
-     *                                       {@link AbstractColumnMappingDefinition.LookupFailBehaviour} exception
-     * @throws ValueMapperException          if specified property can't be mapped and
-     *                                       {@link AbstractColumnMappingDefinition.LookupFailBehaviour} exception
+     * @return {@link ValueExpression} @ if specified property can't be extracted and
+     * {@link AbstractColumnMappingDefinition.LookupFailBehaviour} exception
+     * @throws ValueMapperException if specified property can't be mapped and
+     *                              {@link AbstractColumnMappingDefinition.LookupFailBehaviour} exception
      */
-    public ValueExpression mapRow(final Map<String, AttributeValue> dynamodbRow)
-            throws DynamodbResultWalkerException, ValueMapperException {
+    public ValueExpression mapRow(final Map<String, AttributeValue> dynamodbRow) {
         try {
             final AttributeValue dynamodbProperty = this.column.getPathToSourceProperty().walk(dynamodbRow);
             return mapValue(dynamodbProperty);
@@ -54,5 +52,5 @@ public abstract class AbstractValueMapper {
      * @return the conversion result
      * @throws ValueMapperException if the value can't be mapped
      */
-    protected abstract ValueExpression mapValue(AttributeValue dynamodbProperty) throws ValueMapperException;
+    protected abstract ValueExpression mapValue(AttributeValue dynamodbProperty);
 }

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/JsonMappingFactory.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/JsonMappingFactory.java
@@ -26,7 +26,7 @@ import com.exasol.dynamodb.resultwalker.ObjectDynamodbResultWalker;
  */
 public class JsonMappingFactory implements MappingDefinitionFactory {
     private static final String DEST_TABLE_NAME_KEY = "destTable";
-    private static final String SRC_TABLE_NAME_KEY = "destTable";
+    private static final String SRC_TABLE_NAME_KEY = "srcTable";
     private static final String MAPPING_KEY = "mapping";
     private static final String FIELDS_KEY = "fields";
     private static final String TO_STRING_MAPPING_KEY = "toStringMapping";

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/JsonMappingFactory.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/JsonMappingFactory.java
@@ -26,6 +26,7 @@ import com.exasol.dynamodb.resultwalker.ObjectDynamodbResultWalker;
  */
 public class JsonMappingFactory implements MappingDefinitionFactory {
     private static final String DEST_TABLE_NAME_KEY = "destTable";
+    private static final String SRC_TABLE_NAME_KEY = "destTable";
     private static final String MAPPING_KEY = "mapping";
     private static final String FIELDS_KEY = "fields";
     private static final String TO_STRING_MAPPING_KEY = "toStringMapping";
@@ -91,7 +92,7 @@ public class JsonMappingFactory implements MappingDefinitionFactory {
 
     private void addRootDefinition(final JsonObject definition) throws MappingException {
         final TableMappingDefinition.Builder tableBuilder = TableMappingDefinition
-                .rootTableBuilder(definition.getString(DEST_TABLE_NAME_KEY));
+                .rootTableBuilder(definition.getString(DEST_TABLE_NAME_KEY), definition.getString(SRC_TABLE_NAME_KEY));
         visitRootMapping(definition.getJsonObject(MAPPING_KEY), new IdentityDynamodbResultWalker.Builder(),
                 tableBuilder);
         this.tables.add(tableBuilder.build());

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverter.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverter.java
@@ -81,8 +81,7 @@ public class SchemaMappingDefinitionToSchemaMetadataConverter {
 
     private TableMappingDefinition convertBackTableIntern(final TableMetadata tableMetadata,
             final SchemaMetadata schemaMetadata) throws IOException, ClassNotFoundException {
-        final TableMappingDefinition preliminaryTable;
-        preliminaryTable = findTableInSchemaMetadata(tableMetadata.getName(), schemaMetadata);
+        final TableMappingDefinition preliminaryTable = findTableInSchemaMetadata(tableMetadata.getName(), schemaMetadata);
         /*
          * As the columns are transient in TableMappingDefinition, they must be deserialized from the ColumnMetadata and
          * added separately.

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverter.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverter.java
@@ -27,15 +27,15 @@ public class SchemaMappingDefinitionToSchemaMetadataConverter {
      */
     public SchemaMetadata convert(final SchemaMappingDefinition schemaMappingDefinition) throws IOException {
         final List<TableMetadata> tableMetadata = new ArrayList<>();
-        final HashMap<String, TableMappingDefinition> tableMappings = new HashMap<>();// concrete HashMap is used here
-        // as it is serializable.
+        /* The HashMap is used here instead of the List interface because it is serializable. */
+        final HashMap<String, TableMappingDefinition> tableMappings = new HashMap<>();
         for (final TableMappingDefinition table : schemaMappingDefinition.getTableMappings()) {
             tableMetadata.add(convertTable(table));
             tableMappings.put(table.getExasolName(), table);
         }
         /*
          * Actually the tables should be serialized into TableSchema adapter notes. But as these do not work due to a
-         * bug, they are added here.
+         * bug, they are added here. {@see https://github.com/exasol/dynamodb-virtual-schema/issues/25}
          */
         final String serialized = StringSerializer.serializeToString(new TableMappings(tableMappings));
         return new SchemaMetadata(serialized, tableMetadata);
@@ -94,7 +94,8 @@ public class SchemaMappingDefinitionToSchemaMetadataConverter {
     }
 
     /**
-     * Workaround as tables cant be serialized to {@link TableMetadata}
+     * Workaround as tables cant be serialized to {@link TableMetadata} due to a bug in Exasol.
+     * {@see https://github.com/exasol/dynamodb-virtual-schema/issues/25}
      */
     private TableMappingDefinition findTableInSchemaMetadata(final String tableName,
             final SchemaMetadata schemaMetadata) throws IOException, ClassNotFoundException {
@@ -120,9 +121,9 @@ public class SchemaMappingDefinitionToSchemaMetadataConverter {
     }
 
     /**
-     * This class class is used as a fix for the bug, that {@link TableMetadata} can't store adapter notes. It gets
-     * serialized in the {@link SchemaMetadata} and stores a map that gives the {@link TableMappingDefinition} for its
-     * Exasol name.
+     * This class is used as a fix for the bug because of which {@link TableMetadata} can't store adapter notes.
+     * {@see https://github.com/exasol/dynamodb-virtual-schema/issues/25}. It gets serialized in the
+     * {@link SchemaMetadata} and stores a map that gives the {@link TableMappingDefinition} for its Exasol table name.
      */
     private static class TableMappings implements Serializable {
         private static final long serialVersionUID = -6920869661356098960L;

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverter.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverter.java
@@ -33,6 +33,7 @@ public class SchemaMappingDefinitionToSchemaMetadataConverter {
             tableMetadata.add(convertTable(table));
             tableMappings.put(table.getExasolName(), table);
         }
+        @SuppressWarnings("java:S125") //not commented out code
         /*
          * Actually the tables should be serialized into TableSchema adapter notes. But as these do not work due to a
          * bug, they are added here. {@see https://github.com/exasol/dynamodb-virtual-schema/issues/25}

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.exasol.dynamodb.resultwalker.AbstractDynamodbResultWalker;
+import com.exasol.adapter.dynamodb.documentpath.DocumentPathExpression;
 
 /**
  * Definition of a table mapping from DynamoDB table to Exasol Virtual Schema. Each instance of this class represents a
@@ -18,10 +18,10 @@ public class TableMappingDefinition implements Serializable {
     private final String remoteName;
     private final transient List<AbstractColumnMappingDefinition> columns; // The columns are serialized separately in
                                                                            // {@link ColumnMetadata}.
-    private final AbstractDynamodbResultWalker pathToNestedTable;
+    private final DocumentPathExpression pathToNestedTable;
 
     private TableMappingDefinition(final String exasolName, final String remoteName,
-            final List<AbstractColumnMappingDefinition> columns, final AbstractDynamodbResultWalker pathToNestedTable) {
+            final List<AbstractColumnMappingDefinition> columns, final DocumentPathExpression pathToNestedTable) {
         this.exasolName = exasolName;
         this.remoteName = remoteName;
         this.pathToNestedTable = pathToNestedTable;
@@ -44,7 +44,8 @@ public class TableMappingDefinition implements Serializable {
      * @return {@link TableMappingDefinition.Builder}
      */
     public static Builder rootTableBuilder(final String destName, final String remoteName) {
-        return new Builder(destName, remoteName, null);
+        final DocumentPathExpression emptyPath = new DocumentPathExpression.Builder().build();
+        return new Builder(destName, remoteName, emptyPath);
     }
 
     /**
@@ -57,7 +58,7 @@ public class TableMappingDefinition implements Serializable {
      * @return Builder for {@link TableMappingDefinition}
      */
     public static Builder nestedTableBuilder(final String destName, final String remoteName,
-            final AbstractDynamodbResultWalker pathToNestedTable) {
+            final DocumentPathExpression pathToNestedTable) {
         return new Builder(destName, remoteName, pathToNestedTable);
     }
 
@@ -95,7 +96,7 @@ public class TableMappingDefinition implements Serializable {
      *         list or map from DynamoDB
      */
     public boolean isRootTable() {
-        return this.pathToNestedTable == null;
+        return this.pathToNestedTable.size() == 0;
     }
 
     /**
@@ -105,10 +106,10 @@ public class TableMappingDefinition implements Serializable {
         private final String exasolName;
         private final String remoteName;
         private final List<AbstractColumnMappingDefinition> columns = new ArrayList<>();
-        private final AbstractDynamodbResultWalker pathToNestedTable;
+        private final DocumentPathExpression pathToNestedTable;
 
         private Builder(final String exasolName, final String remoteName,
-                final AbstractDynamodbResultWalker pathToNestedTable) {
+                final DocumentPathExpression pathToNestedTable) {
             this.exasolName = exasolName;
             this.remoteName = remoteName;
             this.pathToNestedTable = pathToNestedTable;

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
@@ -20,10 +20,10 @@ public class TableMappingDefinition implements Serializable {
                                                                            // {@link ColumnMetadata}.
     private final AbstractDynamodbResultWalker pathToNestedTable;
 
-    private TableMappingDefinition(final String exasolName, final String externName,
+    private TableMappingDefinition(final String exasolName, final String remoteName,
             final List<AbstractColumnMappingDefinition> columns, final AbstractDynamodbResultWalker pathToNestedTable) {
         this.exasolName = exasolName;
-        this.remoteName = externName;
+        this.remoteName = remoteName;
         this.pathToNestedTable = pathToNestedTable;
         this.columns = columns;
     }
@@ -52,6 +52,7 @@ public class TableMappingDefinition implements Serializable {
      * create tables extracted from nested lists.
      *
      * @param destName          Name of the Exasol table
+     * @param remoteName        Name of the remote table
      * @param pathToNestedTable Path expression within the document to the nested table
      * @return Builder for {@link TableMappingDefinition}
      */

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
@@ -15,20 +15,23 @@ import com.exasol.dynamodb.resultwalker.AbstractDynamodbResultWalker;
 public class TableMappingDefinition implements Serializable {
     private static final long serialVersionUID = 3568807256753213582L;
     private final String exasolName;
+    private final String remoteName;
     private final transient List<AbstractColumnMappingDefinition> columns; // The columns are serialized separately in
                                                                            // {@link ColumnMetadata}.
     private final AbstractDynamodbResultWalker pathToNestedTable;
 
-    private TableMappingDefinition(final String exasolName, final List<AbstractColumnMappingDefinition> columns,
-            final AbstractDynamodbResultWalker pathToNestedTable) {
+    private TableMappingDefinition(final String exasolName, final String externName,
+            final List<AbstractColumnMappingDefinition> columns, final AbstractDynamodbResultWalker pathToNestedTable) {
         this.exasolName = exasolName;
+        this.remoteName = externName;
         this.pathToNestedTable = pathToNestedTable;
         this.columns = columns;
     }
 
     TableMappingDefinition(final TableMappingDefinition deserialized,
-                           final List<AbstractColumnMappingDefinition> columns) {
+            final List<AbstractColumnMappingDefinition> columns) {
         this.exasolName = deserialized.exasolName;
+        this.remoteName = deserialized.remoteName;
         this.pathToNestedTable = deserialized.pathToNestedTable;
         this.columns = columns;
     }
@@ -40,10 +43,9 @@ public class TableMappingDefinition implements Serializable {
      * @param destName Name of the Exasol table
      * @return {@link TableMappingDefinition.Builder}
      */
-    public static Builder rootTableBuilder(final String destName) {
-        return new Builder(destName, null);
+    public static Builder rootTableBuilder(final String destName, final String remoteName) {
+        return new Builder(destName, remoteName, null);
     }
-
 
     /**
      * Gives an instance of the Builder for {@link TableMappingDefinition}. This version of the builder is used to
@@ -53,9 +55,9 @@ public class TableMappingDefinition implements Serializable {
      * @param pathToNestedTable Path expression within the document to the nested table
      * @return Builder for {@link TableMappingDefinition}
      */
-    public static Builder nestedTableBuilder(final String destName,
+    public static Builder nestedTableBuilder(final String destName, final String remoteName,
             final AbstractDynamodbResultWalker pathToNestedTable) {
-        return new Builder(destName, pathToNestedTable);
+        return new Builder(destName, remoteName, pathToNestedTable);
     }
 
     /**
@@ -65,6 +67,15 @@ public class TableMappingDefinition implements Serializable {
      */
     public String getExasolName() {
         return this.exasolName;
+    }
+
+    /**
+     * Get the name of the remote table that is mapped.
+     *
+     * @return name of the remote table
+     */
+    public String getRemoteName() {
+        return this.remoteName;
     }
 
     /**
@@ -91,11 +102,14 @@ public class TableMappingDefinition implements Serializable {
      */
     public static class Builder {
         private final String exasolName;
+        private final String remoteName;
         private final List<AbstractColumnMappingDefinition> columns = new ArrayList<>();
         private final AbstractDynamodbResultWalker pathToNestedTable;
 
-        private Builder(final String exasolName, final AbstractDynamodbResultWalker pathToNestedTable) {
+        private Builder(final String exasolName, final String remoteName,
+                final AbstractDynamodbResultWalker pathToNestedTable) {
             this.exasolName = exasolName;
+            this.remoteName = remoteName;
             this.pathToNestedTable = pathToNestedTable;
         }
 
@@ -116,8 +130,8 @@ public class TableMappingDefinition implements Serializable {
          * @return {@link TableMappingDefinition}
          */
         public TableMappingDefinition build() {
-            return new TableMappingDefinition(this.exasolName, Collections.unmodifiableList(this.columns),
-                    this.pathToNestedTable);
+            return new TableMappingDefinition(this.exasolName, this.remoteName,
+                    Collections.unmodifiableList(this.columns), this.pathToNestedTable);
         }
     }
 }

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
@@ -1,5 +1,6 @@
 package com.exasol.adapter.dynamodb.mapping;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -9,15 +10,31 @@ import java.util.List;
  * table in the Exasol Virtual Schema. Typically it also represents a DynamoDB table. But it can also represent the data
  * from a nested list or object. See {@link #isRootTable()} for details.
  */
-public class TableMappingDefinition {
+public class TableMappingDefinition implements Serializable {
+    private static final long serialVersionUID = 3568807256753213582L;
     private final String exasolName;
     private final boolean isRootTable;
-    private final List<AbstractColumnMappingDefinition> columns;
+    private final transient List<AbstractColumnMappingDefinition> columns; // The columns are serialized separately in
+                                                                           // {@link ColumnMetadata}.
 
     private TableMappingDefinition(final String exasolName, final boolean isRootTable,
             final List<AbstractColumnMappingDefinition> columns) {
         this.exasolName = exasolName;
         this.isRootTable = isRootTable;
+        this.columns = columns;
+    }
+
+    /**
+     * Creates an instance of {@link TableMappingDefinition} from deserialized version. As the columns are transient
+     * they need to be added again.
+     * 
+     * @param deserialized {@link TableMappingDefinition} retrieved from deserialization
+     * @param columns      Columns deserialized separately
+     */
+    TableMappingDefinition(final TableMappingDefinition deserialized,
+            final List<AbstractColumnMappingDefinition> columns) {
+        this.exasolName = deserialized.exasolName;
+        this.isRootTable = deserialized.isRootTable;
         this.columns = columns;
     }
 

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/TableMappingDefinition.java
@@ -46,9 +46,6 @@ public class TableMappingDefinition implements Serializable {
 
 
     /**
-     * Returns an instance of the Builder.
-
-    /**
      * Gives an instance of the Builder for {@link TableMappingDefinition}. This version of the builder is used to
      * create tables extracted from nested lists.
      *

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/ValueMapperException.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/ValueMapperException.java
@@ -1,11 +1,9 @@
 package com.exasol.adapter.dynamodb.mapping;
 
-import com.exasol.adapter.AdapterException;
-
 /**
  * Exception on failures in column mapping
  */
-public class ValueMapperException extends AdapterException {
+public class ValueMapperException extends RuntimeException {
     private final AbstractColumnMappingDefinition causingColumn;
 
     /**

--- a/src/main/java/com/exasol/adapter/dynamodb/mapping/tostringmapping/ToStringValueMapper.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/mapping/tostringmapping/ToStringValueMapper.java
@@ -25,7 +25,7 @@ public class ToStringValueMapper extends AbstractValueMapper {
     }
 
     @Override
-    protected ValueExpression mapValue(final AttributeValue dynamodbProperty) throws ValueMapperException {
+    protected ValueExpression mapValue(final AttributeValue dynamodbProperty) {
         final ToStringVisitor toStringVisitor = new ToStringVisitor();
         final AttributeValueWrapper attributeValueWrapper = new AttributeValueWrapper(dynamodbProperty);
         attributeValueWrapper.accept(toStringVisitor);
@@ -37,7 +37,7 @@ public class ToStringValueMapper extends AbstractValueMapper {
         }
     }
 
-    private String handleOverflowIfNecessary(final String sourceString) throws OverflowException {
+    private String handleOverflowIfNecessary(final String sourceString) {
         if (sourceString.length() > this.column.getExasolStringSize()) {
             return handleOverflow(sourceString);
         } else {
@@ -45,7 +45,7 @@ public class ToStringValueMapper extends AbstractValueMapper {
         }
     }
 
-    private String handleOverflow(final String tooLongSourceString) throws OverflowException {
+    private String handleOverflow(final String tooLongSourceString) {
         if (this.column.getOverflowBehaviour() == ToStringColumnMappingDefinition.OverflowBehaviour.TRUNCATE) {
             return tooLongSourceString.substring(0, this.column.getExasolStringSize());
         } else {

--- a/src/main/java/com/exasol/adapter/dynamodb/queryresultschema/QueryResultTableSchema.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/queryresultschema/QueryResultTableSchema.java
@@ -3,19 +3,25 @@ package com.exasol.adapter.dynamodb.queryresultschema;
 import java.util.List;
 
 import com.exasol.adapter.dynamodb.mapping.AbstractColumnMappingDefinition;
+import com.exasol.adapter.dynamodb.mapping.TableMappingDefinition;
 
 /**
  * Models the result schema of a query
  */
 public class QueryResultTableSchema {
+
+    private final TableMappingDefinition fromTable;
     private final List<AbstractColumnMappingDefinition> columns;
 
     /**
      * Creates an instance of {@link QueryResultTableSchema}.
-     * 
-     * @param columns in correct order
+     *
+     * @param fromTable remote table to query
+     * @param columns   in correct order
      */
-    public QueryResultTableSchema(final List<AbstractColumnMappingDefinition> columns) {
+    public QueryResultTableSchema(final TableMappingDefinition fromTable,
+            final List<AbstractColumnMappingDefinition> columns) {
+        this.fromTable = fromTable;
         this.columns = columns;
     }
 
@@ -26,5 +32,9 @@ public class QueryResultTableSchema {
      */
     public List<AbstractColumnMappingDefinition> getColumns() {
         return this.columns;
+    }
+
+    public TableMappingDefinition getFromTable() {
+        return this.fromTable;
     }
 }

--- a/src/main/java/com/exasol/adapter/dynamodb/queryresultschema/RowMapper.java
+++ b/src/main/java/com/exasol/adapter/dynamodb/queryresultschema/RowMapper.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.dynamodb.mapping.AbstractColumnMappingDefinition;
 import com.exasol.adapter.dynamodb.mapping.AbstractValueMapper;
 import com.exasol.adapter.dynamodb.mapping.ValueMapperFactory;
@@ -31,7 +30,7 @@ public class RowMapper {
      *
      * @param dynamodbRow DynamoDB row
      */
-    public List<ValueExpression> mapRow(final Map<String, AttributeValue> dynamodbRow) throws AdapterException {
+    public List<ValueExpression> mapRow(final Map<String, AttributeValue> dynamodbRow) {
         final List<ValueExpression> resultValues = new ArrayList<>(this.queryResultTableSchema.getColumns().size());
         for (final AbstractColumnMappingDefinition resultColumn : this.queryResultTableSchema.getColumns()) {
             final AbstractValueMapper valueMapper = new ValueMapperFactory().getValueMapperForColumn(resultColumn);

--- a/src/main/java/com/exasol/adapter/sql/VoidSqlNodeVisitor.java
+++ b/src/main/java/com/exasol/adapter/sql/VoidSqlNodeVisitor.java
@@ -1,6 +1,5 @@
 package com.exasol.adapter.sql;
 
-import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.dynamodb.queryresultschema.QueryResultTableSchemaBuilder;
 
 /**
@@ -11,7 +10,7 @@ public abstract class VoidSqlNodeVisitor implements SqlNodeVisitor<Void> {
     private static final String UNSUPPORTED_MESSAGE = "A handling for this SQL statement part was not implemented yet.";
 
     @Override
-    public Void visit(final SqlSelectList selectList) throws AdapterException {
+    public Void visit(final SqlSelectList selectList) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 

--- a/src/main/java/com/exasol/dynamodb/resultwalker/AbstractDynamodbResultWalker.java
+++ b/src/main/java/com/exasol/dynamodb/resultwalker/AbstractDynamodbResultWalker.java
@@ -32,24 +32,21 @@ public abstract class AbstractDynamodbResultWalker implements Serializable {
      *
      * @return AttributeValue specified by the path modeled by a chain of this objects
      */
-    public AttributeValue walk(final Map<String, AttributeValue> item) throws DynamodbResultWalkerException {
+    public AttributeValue walk(final Map<String, AttributeValue> item) {
         final AttributeValue attributeValueRepresentingItem = new AttributeValue();
         attributeValueRepresentingItem.setM(item);
         return walk(attributeValueRepresentingItem, "");
     }
 
-    private AttributeValue walk(final AttributeValue attributeValue, final String path)
-            throws DynamodbResultWalkerException {
+    private AttributeValue walk(final AttributeValue attributeValue, final String path) {
         return applyNext(applyThis(attributeValue, path), path);
     }
 
-    protected abstract AttributeValue applyThis(AttributeValue attributeValue, String path)
-            throws DynamodbResultWalkerException;
+    protected abstract AttributeValue applyThis(AttributeValue attributeValue, String path);
 
     protected abstract String stepDescription();
 
-    private AttributeValue applyNext(final AttributeValue attributeValue, final String path)
-            throws DynamodbResultWalkerException {
+    private AttributeValue applyNext(final AttributeValue attributeValue, final String path) {
         if (this.next != null) {
             return this.next.walk(attributeValue, path + stepDescription());
         }

--- a/src/main/java/com/exasol/dynamodb/resultwalker/DynamodbResultWalkerException.java
+++ b/src/main/java/com/exasol/dynamodb/resultwalker/DynamodbResultWalkerException.java
@@ -1,12 +1,10 @@
 package com.exasol.dynamodb.resultwalker;
 
-import com.exasol.adapter.AdapterException;
-
 /**
  * Exception thrown when the modeled path does not exist.
  */
 @SuppressWarnings("serial")
-public class DynamodbResultWalkerException extends AdapterException {
+public class DynamodbResultWalkerException extends RuntimeException {
     private final String currentPath;
 
     /**

--- a/src/main/java/com/exasol/dynamodb/resultwalker/ObjectDynamodbResultWalker.java
+++ b/src/main/java/com/exasol/dynamodb/resultwalker/ObjectDynamodbResultWalker.java
@@ -21,8 +21,7 @@ public class ObjectDynamodbResultWalker extends AbstractDynamodbResultWalker {
     }
 
     @Override
-    protected AttributeValue applyThis(final AttributeValue attributeValue, final String path)
-            throws DynamodbResultWalkerException {
+    protected AttributeValue applyThis(final AttributeValue attributeValue, final String path) {
         if (attributeValue.getM() == null) {
             throw new DynamodbResultWalkerException("Not an object", path);
         }

--- a/src/test/java/com/exasol/adapter/dynamodb/DynamodbAdapterTestLocalIT.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/DynamodbAdapterTestLocalIT.java
@@ -44,7 +44,7 @@ public class DynamodbAdapterTestLocalIT {
             .withNetwork(NETWORK).withExposedPorts(8888).withLogConsumer(new Slf4jLogConsumer(LOGGER));
     private static final String TEST_SCHEMA = "TEST";
     private static final String DYNAMODB_CONNECTION = "DYNAMODB_CONNECTION";
-    private static final String DYNAMO_TABLE_NAME = "JB_Books";
+    private static final String DYNAMO_TABLE_NAME = "MY_BOOKS";
     private static DynamodbTestInterface dynamodbTestInterface;
     private static ExasolTestInterface exasolTestInterface;
 

--- a/src/test/java/com/exasol/adapter/dynamodb/ValueExpressionsToSqlSelectFromValuesConverterTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/ValueExpressionsToSqlSelectFromValuesConverterTest.java
@@ -17,8 +17,9 @@ import com.exasol.sql.expression.ValueExpression;
 
 public class ValueExpressionsToSqlSelectFromValuesConverterTest {
     QueryResultTableSchema getTestTable() {
-        return new QueryResultTableSchema(List.of(new ToJsonColumnMappingDefinition(
-                new AbstractColumnMappingDefinition.ConstructorParameters("json", new IdentityDynamodbResultWalker(),
+        return new QueryResultTableSchema(null,
+                List.of(new ToJsonColumnMappingDefinition(new AbstractColumnMappingDefinition.ConstructorParameters(
+                        "json", new IdentityDynamodbResultWalker(),
                         AbstractColumnMappingDefinition.LookupFailBehaviour.DEFAULT_VALUE))));
     }
 

--- a/src/test/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathWalkerTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/documentpath/DocumentPathWalkerTest.java
@@ -23,7 +23,8 @@ public class DocumentPathWalkerTest {
     @Test
     void testWalkEmptyPath() throws DocumentPathWalkerException {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().build();
-        final List<DocumentNode> result = new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE);
+        final List<DocumentNode<MockVisitor>> result = new DocumentPathWalker<MockVisitor>(pathExpression)
+                .walkThroughDocument(TEST_OBJECT_NODE);
         assertThat(result, containsInAnyOrder(TEST_OBJECT_NODE));
     }
 
@@ -31,16 +32,17 @@ public class DocumentPathWalkerTest {
     void testWalkObjectPath() throws DocumentPathWalkerException {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addObjectLookup("key")
                 .build();
-        final List<DocumentNode> result = new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE);
+        final List<DocumentNode<MockVisitor>> result = new DocumentPathWalker<MockVisitor>(pathExpression)
+                .walkThroughDocument(TEST_OBJECT_NODE);
         assertThat(result, containsInAnyOrder(NESTED_VALUE1));
     }
 
     @Test
-    void testNotAnObject() throws DocumentPathWalkerException {
+    void testNotAnObject() {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addObjectLookup("key")
                 .addObjectLookup("key2").build();
         final DocumentPathWalkerException exception = assertThrows(DocumentPathWalkerException.class,
-                () -> new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
+                () -> new DocumentPathWalker<MockVisitor>(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
         assertAll(() -> assertThat(exception.getCurrentPath(), equalTo("/key")),
                 () -> assertThat(exception.getMessage(),
                         equalTo("Can't perform key lookup on non object. (requested key= key2) (current path= /key)")));
@@ -51,7 +53,7 @@ public class DocumentPathWalkerTest {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addObjectLookup("unknownKey")
                 .build();
         final DocumentPathWalkerException exception = assertThrows(DocumentPathWalkerException.class,
-                () -> new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
+                () -> new DocumentPathWalker<MockVisitor>(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
         assertAll(() -> assertThat(exception.getCurrentPath(), equalTo("/")), () -> assertThat(exception.getMessage(),
                 equalTo("The requested lookup key (unknownKey) is not present in this object. (current path= /)")));
     }
@@ -59,38 +61,40 @@ public class DocumentPathWalkerTest {
     @Test
     void testArrayLookup() throws DocumentPathWalkerException {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addArrayLookup(0).build();
-        final List<DocumentNode> result = new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_ARRAY_NODE);
+        final List<DocumentNode<MockVisitor>> result = new DocumentPathWalker<MockVisitor>(pathExpression)
+                .walkThroughDocument(TEST_ARRAY_NODE);
         assertThat(result, containsInAnyOrder(NESTED_VALUE1));
     }
 
     @Test
-    void testOutOfBoundsArrayLookup() throws DocumentPathWalkerException {
+    void testOutOfBoundsArrayLookup() {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addArrayLookup(10).build();
         final DocumentPathWalkerException exception = assertThrows(DocumentPathWalkerException.class,
-                () -> new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_ARRAY_NODE));
+                () -> new DocumentPathWalker<MockVisitor>(pathExpression).walkThroughDocument(TEST_ARRAY_NODE));
         assertThat(exception.getMessage(), equalTo("Can't perform array lookup: Index: 10 Size: 2 (current path= /)"));
     }
 
     @Test
-    void testArrayLookupOnNonArray() throws DocumentPathWalkerException {
+    void testArrayLookupOnNonArray() {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addArrayLookup(10).build();
         final DocumentPathWalkerException exception = assertThrows(DocumentPathWalkerException.class,
-                () -> new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
+                () -> new DocumentPathWalker<MockVisitor>(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
         assertThat(exception.getMessage(), equalTo("Can't perform array lookup on non array. (current path= /)"));
     }
 
     @Test
     void testArrayAll() throws DocumentPathWalkerException {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addArrayAll().build();
-        final List<DocumentNode> result = new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_ARRAY_NODE);
+        final List<DocumentNode<MockVisitor>> result = new DocumentPathWalker<MockVisitor>(pathExpression)
+                .walkThroughDocument(TEST_ARRAY_NODE);
         assertThat(result, containsInAnyOrder(NESTED_VALUE1, NESTED_VALUE2));
     }
 
     @Test
-    void testArrayAllOnNonArray() throws DocumentPathWalkerException {
+    void testArrayAllOnNonArray() {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addArrayAll().build();
         final DocumentPathWalkerException exception = assertThrows(DocumentPathWalkerException.class,
-                () -> new DocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
+                () -> new DocumentPathWalker<MockVisitor>(pathExpression).walkThroughDocument(TEST_OBJECT_NODE));
         assertThat(exception.getMessage(), equalTo("Can't perform array lookup on non array. (current path= /)"));
     }
 }

--- a/src/test/java/com/exasol/adapter/dynamodb/documentpath/LinearDocumentPathWalkerTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/documentpath/LinearDocumentPathWalkerTest.java
@@ -19,7 +19,8 @@ public class LinearDocumentPathWalkerTest {
     void testWalk() throws DocumentPathWalkerException {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addObjectLookup("key")
                 .build();
-        final DocumentNode result = new LinearDocumentPathWalker(pathExpression).walkThroughDocument(TEST_OBJECT_NODE);
+        final DocumentNode<MockVisitor> result = new LinearDocumentPathWalker<MockVisitor>(pathExpression)
+                .walkThroughDocument(TEST_OBJECT_NODE);
         assertThat(result, equalTo(NESTED_VALUE));
     }
 
@@ -27,7 +28,7 @@ public class LinearDocumentPathWalkerTest {
     void testNonLinearPath() {
         final DocumentPathExpression pathExpression = new DocumentPathExpression.Builder().addArrayAll().build();
         final DocumentPathWalkerException exception = assertThrows(DocumentPathWalkerException.class,
-                () -> new LinearDocumentPathWalker(pathExpression));
+                () -> new LinearDocumentPathWalker<MockVisitor>(pathExpression));
         assertThat(exception.getMessage(), equalTo(
                 "The given path is not a linear path. You can either remove the ArrayAllSegments from path or use a DocumentPathWalker."));
     }

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/AbstractValueMapperTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/AbstractValueMapperTest.java
@@ -19,7 +19,7 @@ import com.exasol.sql.expression.ValueExpression;
 
 public class AbstractValueMapperTest {
     @Test
-    void testLookup() throws DynamodbResultWalkerException, ValueMapperException {
+    void testLookup() {
         final ObjectDynamodbResultWalker resultWalker = new ObjectDynamodbResultWalker("isbn", null);
         final MockColumnMappingDefinition columnMappingDefinition = new MockColumnMappingDefinition("d", resultWalker,
                 AbstractColumnMappingDefinition.LookupFailBehaviour.EXCEPTION);

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/HardCodedMappingFactory.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/HardCodedMappingFactory.java
@@ -12,7 +12,7 @@ import com.exasol.dynamodb.resultwalker.IdentityDynamodbResultWalker;
 public class HardCodedMappingFactory implements MappingDefinitionFactory {
     @Override
     public SchemaMappingDefinition getSchemaMapping() {
-        final TableMappingDefinition table = TableMappingDefinition.rootTableBuilder("testTable")
+        final TableMappingDefinition table = TableMappingDefinition.rootTableBuilder("testTable", "srcTable")
                 .withColumnMappingDefinition(
                         new ToJsonColumnMappingDefinition(new AbstractColumnMappingDefinition.ConstructorParameters(
                                 "json", new IdentityDynamodbResultWalker(),

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/JsonMappingFactoryTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/JsonMappingFactoryTest.java
@@ -49,6 +49,7 @@ public class JsonMappingFactoryTest {
                 .filter(column -> column.getExasolColumnName().equals("NAME")).findAny().get();
         assertAll(() -> assertThat(tables.size(), equalTo(1)), //
                 () -> assertThat(table.getExasolName(), equalTo("BOOKS")),
+                () -> assertThat(table.getRemoteName(), equalTo("MY_BOOKS")),
                 () -> assertThat(columnNames, containsInAnyOrder("ISBN", "NAME", "AUTHOR_NAME")),
                 () -> assertThat(isbnColumn.getExasolStringSize(), equalTo(20)),
                 () -> assertThat(isbnColumn.getOverflowBehaviour(),

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverterTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverterTest.java
@@ -3,6 +3,7 @@ package com.exasol.adapter.dynamodb.mapping;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.io.IOException;
 import java.util.List;
@@ -17,11 +18,14 @@ import com.exasol.adapter.metadata.TableMetadata;
 import com.exasol.dynamodb.resultwalker.IdentityDynamodbResultWalker;
 
 public class SchemaMappingDefinitionToSchemaMetadataConverterTest {
+    private static final String TABLE_NAME = "testTable";
+    private static final String COLUMN_NAME = "json";
+
     public SchemaMappingDefinition getSchemaMapping() {
-        final TableMappingDefinition table = TableMappingDefinition.builder("testTable", true)
+        final TableMappingDefinition table = TableMappingDefinition.builder(TABLE_NAME, true)
                 .withColumnMappingDefinition(
                         new ToJsonColumnMappingDefinition(new AbstractColumnMappingDefinition.ConstructorParameters(
-                                "json", new IdentityDynamodbResultWalker(),
+                                COLUMN_NAME, new IdentityDynamodbResultWalker(),
                                 AbstractColumnMappingDefinition.LookupFailBehaviour.DEFAULT_VALUE)))
                 .build();
         return new SchemaMappingDefinition(List.of(table));
@@ -35,20 +39,35 @@ public class SchemaMappingDefinitionToSchemaMetadataConverterTest {
         final List<TableMetadata> tables = schemaMetadata.getTables();
         assertThat(tables.size(), equalTo(1));
         final TableMetadata firstTable = tables.get(0);
-        assertThat(firstTable.getName(), equalTo("testTable"));
+        assertThat(firstTable.getName(), equalTo(TABLE_NAME));
         final List<String> columnNames = firstTable.getColumns().stream().map(ColumnMetadata::getName)
                 .collect(Collectors.toList());
-        assertThat(columnNames, containsInAnyOrder("json"));
+        assertThat(columnNames, containsInAnyOrder(COLUMN_NAME));
     }
 
     @Test
-    void testSerialization() throws IOException, ClassNotFoundException {
+    void testColumnSerialization() throws IOException, ClassNotFoundException {
         final SchemaMappingDefinition schemaMapping = getSchemaMapping();
         final SchemaMetadata schemaMetadata = new SchemaMappingDefinitionToSchemaMetadataConverter()
                 .convert(schemaMapping);
         final ColumnMetadata firstColumnMetadata = schemaMetadata.getTables().get(0).getColumns().get(0);
         final AbstractColumnMappingDefinition columnMappingDefinition = new SchemaMappingDefinitionToSchemaMetadataConverter()
                 .convertBackColumn(firstColumnMetadata);
-        assertThat(columnMappingDefinition.getExasolColumnName(), equalTo("json"));
+        assertThat(columnMappingDefinition.getExasolColumnName(), equalTo(COLUMN_NAME));
+    }
+
+    @Test
+    void testTableSerialization() throws IOException, ClassNotFoundException {
+        final SchemaMappingDefinition schemaMapping = getSchemaMapping();
+        final SchemaMappingDefinitionToSchemaMetadataConverter converter = new SchemaMappingDefinitionToSchemaMetadataConverter();
+        final SchemaMetadata schemaMetadata = converter.convert(schemaMapping);
+        final TableMetadata firstTableMetadata = schemaMetadata.getTables().get(0);
+        final TableMappingDefinition tableMappingDefinition = converter.convertBackTable(firstTableMetadata,
+                schemaMetadata);
+        assertAll(//
+                () -> assertThat(tableMappingDefinition.getExasolName(), equalTo(TABLE_NAME)), //
+                () -> assertThat(tableMappingDefinition.getColumns().size(), equalTo(1)), //
+                () -> assertThat(tableMappingDefinition.getColumns().get(0).getExasolColumnName(), equalTo(COLUMN_NAME))//
+        );
     }
 }

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverterTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/SchemaMappingDefinitionToSchemaMetadataConverterTest.java
@@ -49,7 +49,7 @@ public class SchemaMappingDefinitionToSchemaMetadataConverterTest {
     }
 
     @Test
-    void testColumnSerialization() throws IOException, ClassNotFoundException {
+    void testColumnSerialization() throws IOException {
         final SchemaMappingDefinition schemaMapping = getSchemaMapping();
         final SchemaMetadata schemaMetadata = new SchemaMappingDefinitionToSchemaMetadataConverter()
                 .convert(schemaMapping);
@@ -60,7 +60,7 @@ public class SchemaMappingDefinitionToSchemaMetadataConverterTest {
     }
 
     @Test
-    void testTableSerialization() throws IOException, ClassNotFoundException {
+    void testTableSerialization() throws IOException {
         final SchemaMappingDefinition schemaMapping = getSchemaMapping();
         final SchemaMappingDefinitionToSchemaMetadataConverter converter = new SchemaMappingDefinitionToSchemaMetadataConverter();
         final SchemaMetadata schemaMetadata = converter.convert(schemaMapping);

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/tojsonmapping/ToJsonValueMapperTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/tojsonmapping/ToJsonValueMapperTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.dynamodb.mapping.AbstractColumnMappingDefinition;
 import com.exasol.dynamodb.attributevalue.AttributeValueTestUtils;
 import com.exasol.dynamodb.resultwalker.IdentityDynamodbResultWalker;
@@ -18,7 +17,7 @@ public class ToJsonValueMapperTest {
     private static final String DEST_COLUMN = "destColumn";
 
     @Test
-    void testConvertRowBasic() throws AdapterException {
+    void testConvertRowBasic() {
         final ToJsonColumnMappingDefinition toStringColumnMappingDefinition = new ToJsonColumnMappingDefinition(
                 new AbstractColumnMappingDefinition.ConstructorParameters(DEST_COLUMN,
                         new IdentityDynamodbResultWalker(),

--- a/src/test/java/com/exasol/adapter/dynamodb/mapping/tostringmapping/ToStringValueMapperTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/mapping/tostringmapping/ToStringValueMapperTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.dynamodb.mapping.AbstractColumnMappingDefinition;
 import com.exasol.dynamodb.resultwalker.ObjectDynamodbResultWalker;
 import com.exasol.sql.expression.ValueExpression;
@@ -23,7 +22,7 @@ public class ToStringValueMapperTest {
     private static final String DEST_COLUMN = "destColumn";
 
     @Test
-    void testConvertStringRowBasic() throws AdapterException {
+    void testConvertStringRowBasic() {
         final AbstractColumnMappingDefinition.ConstructorParameters columnParameters = new AbstractColumnMappingDefinition.ConstructorParameters(
                 DEST_COLUMN, new ObjectDynamodbResultWalker(TEST_SOURCE_COLUMN, null),
                 AbstractColumnMappingDefinition.LookupFailBehaviour.DEFAULT_VALUE);
@@ -35,7 +34,7 @@ public class ToStringValueMapperTest {
     }
 
     @Test
-    void testConvertNumberRowBasic() throws AdapterException {
+    void testConvertNumberRowBasic() {
         final AbstractColumnMappingDefinition.ConstructorParameters columnParameters = new AbstractColumnMappingDefinition.ConstructorParameters(
                 DEST_COLUMN, new ObjectDynamodbResultWalker(TEST_SOURCE_COLUMN, null),
                 AbstractColumnMappingDefinition.LookupFailBehaviour.DEFAULT_VALUE);
@@ -61,7 +60,7 @@ public class ToStringValueMapperTest {
     }
 
     @Test
-    void testConvertRowOverflowTruncate() throws AdapterException {
+    void testConvertRowOverflowTruncate() {
         final AbstractColumnMappingDefinition.ConstructorParameters columnParameters = new AbstractColumnMappingDefinition.ConstructorParameters(
                 DEST_COLUMN, new ObjectDynamodbResultWalker(TEST_SOURCE_COLUMN, null),
                 AbstractColumnMappingDefinition.LookupFailBehaviour.DEFAULT_VALUE);

--- a/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/QueryResultTableSchemaBuilderTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/QueryResultTableSchemaBuilderTest.java
@@ -14,6 +14,7 @@ import com.exasol.adapter.dynamodb.mapping.AbstractColumnMappingDefinition;
 import com.exasol.adapter.dynamodb.mapping.HardCodedMappingFactory;
 import com.exasol.adapter.dynamodb.mapping.SchemaMappingDefinitionToSchemaMetadataConverter;
 import com.exasol.adapter.metadata.ColumnMetadata;
+import com.exasol.adapter.metadata.SchemaMetadata;
 import com.exasol.adapter.metadata.TableMetadata;
 import com.exasol.adapter.sql.SqlSelectList;
 import com.exasol.adapter.sql.SqlStatementSelect;
@@ -22,12 +23,13 @@ import com.exasol.adapter.sql.SqlTable;
 public class QueryResultTableSchemaBuilderTest {
     @Test
     void testBuildSelectStar() throws IOException, AdapterException {
-        final TableMetadata tableMetadata = new SchemaMappingDefinitionToSchemaMetadataConverter()
-                .convert(new HardCodedMappingFactory().getSchemaMapping()).getTables().get(0);
+        final SchemaMetadata schemaMetadata = new SchemaMappingDefinitionToSchemaMetadataConverter()
+                .convert(new HardCodedMappingFactory().getSchemaMapping());
+        final TableMetadata tableMetadata = schemaMetadata.getTables().get(0);
         final SqlStatementSelect statement = SqlStatementSelect.builder()
                 .fromClause(new SqlTable(tableMetadata.getName(), tableMetadata))
                 .selectList(SqlSelectList.createSelectStarSelectList()).build();
-        final QueryResultTableSchema resultTable = new QueryResultTableSchemaBuilder().build(statement);
+        final QueryResultTableSchema resultTable = new QueryResultTableSchemaBuilder().build(statement, schemaMetadata);
         final List<String> actualDestinationNames = resultTable.getColumns().stream()
                 .map(AbstractColumnMappingDefinition::getExasolColumnName).collect(Collectors.toList());
         final String[] expectedDestinationNames = tableMetadata.getColumns().stream().map(ColumnMetadata::getName)

--- a/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/QueryResultTableSchemaTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/QueryResultTableSchemaTest.java
@@ -2,18 +2,25 @@ package com.exasol.adapter.dynamodb.queryresultschema;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import com.exasol.adapter.dynamodb.mapping.MockColumnMappingDefinition;
+import com.exasol.adapter.dynamodb.mapping.TableMappingDefinition;
 
 public class QueryResultTableSchemaTest {
     @Test
     void testSetAndGetColumns() {
         final MockColumnMappingDefinition columnDefinition = new MockColumnMappingDefinition("", null, null);
-        final QueryResultTableSchema queryResultTableSchema = new QueryResultTableSchema(List.of(columnDefinition));
-        assertThat(queryResultTableSchema.getColumns(), containsInAnyOrder(columnDefinition));
+        final TableMappingDefinition tableDefinition = TableMappingDefinition.rootTableBuilder("", "")
+                .withColumnMappingDefinition(columnDefinition).build();
+        final QueryResultTableSchema queryResultTableSchema = new QueryResultTableSchema(tableDefinition,
+                List.of(columnDefinition));
+        assertAll(() -> assertThat(queryResultTableSchema.getColumns(), containsInAnyOrder(columnDefinition)),
+                () -> assertThat(queryResultTableSchema.getFromTable(), equalTo(tableDefinition)));
     }
 }

--- a/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/RowMapperTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/RowMapperTest.java
@@ -22,7 +22,8 @@ public class RowMapperTest {
         final ToJsonColumnMappingDefinition mappingDefinition = new ToJsonColumnMappingDefinition(
                 new AbstractColumnMappingDefinition.ConstructorParameters("test", new IdentityDynamodbResultWalker(),
                         AbstractColumnMappingDefinition.LookupFailBehaviour.EXCEPTION));
-        final QueryResultTableSchema queryResultTableSchema = new QueryResultTableSchema(List.of(mappingDefinition));
+        final QueryResultTableSchema queryResultTableSchema = new QueryResultTableSchema(null,
+                List.of(mappingDefinition));
         final List<ValueExpression> exasolRow = new RowMapper(queryResultTableSchema)
                 .mapRow(Map.of("testKey", AttributeValueTestUtils.forString("testValue")));
         assertThat(exasolRow.get(0).toString(), equalTo("{\"testKey\":\"testValue\"}"));

--- a/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/RowMapperTest.java
+++ b/src/test/java/com/exasol/adapter/dynamodb/queryresultschema/RowMapperTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.dynamodb.mapping.AbstractColumnMappingDefinition;
 import com.exasol.adapter.dynamodb.mapping.tojsonmapping.ToJsonColumnMappingDefinition;
 import com.exasol.dynamodb.attributevalue.AttributeValueTestUtils;
@@ -18,7 +17,7 @@ import com.exasol.sql.expression.ValueExpression;
 public class RowMapperTest {
 
     @Test
-    public void testMapRow() throws AdapterException {
+    public void testMapRow() {
         final ToJsonColumnMappingDefinition mappingDefinition = new ToJsonColumnMappingDefinition(
                 new AbstractColumnMappingDefinition.ConstructorParameters("test", new IdentityDynamodbResultWalker(),
                         AbstractColumnMappingDefinition.LookupFailBehaviour.EXCEPTION));

--- a/src/test/java/com/exasol/dynamodb/resultwalker/AbstractDynamodbResultWalkerTest.java
+++ b/src/test/java/com/exasol/dynamodb/resultwalker/AbstractDynamodbResultWalkerTest.java
@@ -30,14 +30,14 @@ public class AbstractDynamodbResultWalkerTest {
     }
 
     @Test
-    void testIdentityWalker() throws DynamodbResultWalkerException {
+    void testIdentityWalker() {
         final Map<String, AttributeValue> testData = getTestData();
         final IdentityDynamodbResultWalker walker = new IdentityDynamodbResultWalker();
         assertThat(walker.walk(testData).getM(), equalTo(testData));
     }
 
     @Test
-    void testChainedIdentityWalker() throws DynamodbResultWalkerException {
+    void testChainedIdentityWalker() {
         final Map<String, AttributeValue> testData = getTestData();
         final IdentityDynamodbResultWalker walker = new IdentityDynamodbResultWalker(
                 new IdentityDynamodbResultWalker());
@@ -45,14 +45,14 @@ public class AbstractDynamodbResultWalkerTest {
     }
 
     @Test
-    void testObjectWalker() throws DynamodbResultWalkerException {
+    void testObjectWalker() {
         final Map<String, AttributeValue> testData = getTestData();
         final ObjectDynamodbResultWalker walker = new ObjectDynamodbResultWalker("isbn", null);
         assertThat(walker.walk(testData), equalTo(testData.get("isbn")));
     }
 
     @Test
-    void testChainedObjectWalker() throws DynamodbResultWalkerException {
+    void testChainedObjectWalker() {
         final Map<String, AttributeValue> testData = getTestData();
         final ObjectDynamodbResultWalker walker = new ObjectDynamodbResultWalker("publisher",
                 new ObjectDynamodbResultWalker("name", null));


### PR DESCRIPTION
Before this PR the name of the DynamoDB table was hardcoded in `DynamodbAdapter`. Now the table defined in the Schema Mapping Language is used. (Closes #18)